### PR TITLE
Add graphql endpoint

### DIFF
--- a/indexers/archive/docker-compose.yml
+++ b/indexers/archive/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack:0.13.3
+    image: localstack/localstack
     ports:
       - "127.0.0.1:4510-4559:4510-4559"  # external service port range
       - "127.0.0.1:4566:4566"            # LocalStack Edge Proxy
@@ -20,8 +20,8 @@ services:
       - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
       - AWS_DEFAULT_REGION=eu-west-1
       - EDGE_PORT=4566
-      - SERVICES=lambda,s3,sqs,cloudformation,sts,iam,cloudwatch,events
       - DOCKER_HOST=unix:///var/run/docker.sock
+      - LAMBDA_EXECUTOR=docker-reuse
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - HOSTNAME_EXTERNAL=host.docker.internal
     volumes:

--- a/indexers/archive/package.json
+++ b/indexers/archive/package.json
@@ -16,6 +16,7 @@
     "start:local": "docker-compose up -d && yarn run deploy:local"
   },
   "dependencies": {
+    "@vendia/serverless-express": "^4.8.0",
     "aws-utils": "0.0.1",
     "indexer-utils": "0.0.1",
     "yargs": "^17.4.1"

--- a/indexers/archive/serverless.ts
+++ b/indexers/archive/serverless.ts
@@ -1,5 +1,6 @@
 import producer from '@functions/producer';
 import worker from '@functions/worker';
+import query from '@functions/query';
 import type { AWS } from '@serverless/typescript';
 import stageConfigFactory from './serverless/config/stage-config';
 import {getContext} from "./serverless/util/context";
@@ -60,7 +61,7 @@ const serverlessConfiguration: AWS = {
             JobQueue: {
                 Type: 'AWS::SQS::Queue',
                 Properties: {
-                    QueueName: 'JobQueue',
+                    QueueName: stageConfig.getJobQueueName(),
                     VisibilityTimeout: 60
                 }
             },
@@ -74,7 +75,8 @@ const serverlessConfiguration: AWS = {
     },
     functions: {
         producer,
-        worker
+        worker,
+        query
     },
     package: {individually: true},
     custom: {

--- a/indexers/archive/serverless/config/stage-config.ts
+++ b/indexers/archive/serverless/config/stage-config.ts
@@ -83,6 +83,13 @@ export default (stage: string) => {
                 envVar: process.env['PRODUCER_BUCKET_NAME'],
                 default: `${stage}-producer-bucket`
             }
+        ),
+        getJobQueueName: () => getParameterForStage(
+            stage,
+            {
+                envVar: process.env['JOB_QUEUE_NAME'],
+                default: `${stage}-producer-bucket`
+            }
         )
     }
 }

--- a/indexers/archive/serverless/functions/query/handler.ts
+++ b/indexers/archive/serverless/functions/query/handler.ts
@@ -1,0 +1,16 @@
+import serverlessExpress from "@vendia/serverless-express";
+import { graphqlServer } from 'indexer-utils';
+import schema from '@app/schema';
+import config from "../../../src/config";
+import mongoose from "mongoose";
+let serverlessExpressInstance;
+
+export default async (event, context) => {
+    if (!serverlessExpressInstance) {
+        await mongoose.connect(config.mongoUri);
+        const app = graphqlServer(schema);
+        serverlessExpressInstance = serverlessExpress({ app });
+    }
+
+    return serverlessExpressInstance(event, context);
+}

--- a/indexers/archive/serverless/functions/query/index.ts
+++ b/indexers/archive/serverless/functions/query/index.ts
@@ -1,0 +1,29 @@
+import { handlerPath } from '@libs/handler-resolver';
+import {getContext} from "../../util/context";
+import stageConfigFactory from "../../config/stage-config";
+
+const context = getContext();
+const stageConfig = stageConfigFactory(context.options.stage);
+
+export default {
+    handler: `${handlerPath(__dirname)}/handler.default`,
+    events: [
+        {
+            http: {
+                path: 'graphql',
+                method: 'get',
+                cors: true
+            }
+        },
+        {
+            http: {
+                path: 'graphql',
+                method: 'post',
+                cors: true
+            }
+        }
+    ],
+    environment: {
+        MONGO_URI: stageConfig.getMongoURI()
+    },
+};

--- a/packages/indexer-utils/package.json
+++ b/packages/indexer-utils/package.json
@@ -9,6 +9,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
+    "body-parser": "^1.20.0",
     "evm": "^0.2.0"
   }
 }

--- a/packages/indexer-utils/src/graphql-server.ts
+++ b/packages/indexer-utils/src/graphql-server.ts
@@ -1,12 +1,15 @@
 import express from 'express';
+import bodyParser from 'body-parser';
 import { graphqlHTTP } from 'express-graphql';
 import { GraphQLSchema } from 'graphql';
 
-export default async function graphqlServer(
+export default function graphqlServer(
   schema: GraphQLSchema,
-  port: number
+  port?: number
 ) {
   const app = express();
+
+  app.use(bodyParser.json({limit: '50mb'}));
   app.use(
     '/graphql',
     graphqlHTTP(() => ({
@@ -14,7 +17,12 @@ export default async function graphqlServer(
       graphiql: { headerEditorEnabled: true },
     }))
   );
-  app.listen(port, () => {
-    console.log(`Graphql server listening on port: ${port}`);
-  });
+
+  if (port) {
+      app.listen(port, () => {
+          console.log(`Graphql server listening on port: ${port}`);
+      });
+  }
+
+  return app;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,6 +862,11 @@
     "@typescript-eslint/types" "5.21.0"
     eslint-visitor-keys "^3.0.0"
 
+"@vendia/serverless-express@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@vendia/serverless-express/-/serverless-express-4.8.0.tgz#2e3410a07e35487e4e1572c4e2700dfba0c933c2"
+  integrity sha512-ELqWnPq+Y0GPnVa7S63pe/SpxYPwksZhuy+lE50S3WabYOzFTusJda0s9TaDZCkJ/hp8fhbDpGr9eA1UhIlVOQ==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1220,7 +1225,7 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-body-parser@1.20.0:
+body-parser@1.20.0, body-parser@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
   integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
@@ -5832,15 +5837,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-underscore@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
-
-underscore@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+underscore@1.12.1, underscore@1.9.1, underscore@^1.12.1:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
+  integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
 
 uni-global@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
To make as few changes as possible I am using express in the lambda - which we might want to avoid?

I looked at doing it with native api gateway / lambdas - but it's a lot more work, requires more AWS specific code and we would have to reimplement the integration with the graphiQl package (or lose the UI). 

 Given we only plan to have a single endpoint it might not be so much of an issue.