### PR TITLE
Remove underscored method & event IDs

### DIFF
--- a/indexers/token-activity/src/indexer/events-handler.ts
+++ b/indexers/token-activity/src/indexer/events-handler.ts
@@ -24,19 +24,13 @@ export default async function eventsHandler(
 ) {
   // get the events
   const logs = await Promise.all(
-    sigs.map(async (sig) => {
-      const logs = await query.archive.logs({
+    sigs.map((sig) =>
+      query.archive.logs({
         startBlock,
         endBlock,
         eventId: `0x${sig.ID}`,
-      });
-      const _logs = await query.archive.logs({
-        startBlock,
-        endBlock,
-        eventId: `0x${sig._ID}`,
-      });
-      return [...logs, ..._logs];
-    }),
+      }),
+    ),
   );
 
   // filter non-erc standard logs
@@ -55,9 +49,7 @@ export default async function eventsHandler(
   await model.insertMany(
     ercLogs
       .map((log) => {
-        const sig = sigs.find((sig) =>
-          [`0x${sig.ID}`, `0x${sig._ID}`].includes(log.topic0),
-        )!;
+        const sig = sigs.find((sig) => `0x${sig.ID}` === log.topic0)!;
 
         let decoded: DecodedEvent;
         try {

--- a/indexers/token-activity/src/indexer/extrinsics-handler.ts
+++ b/indexers/token-activity/src/indexer/extrinsics-handler.ts
@@ -24,8 +24,8 @@ export default async function extrinsicsHandler(
 ) {
   // get the extrinsics
   const txs = await Promise.all(
-    extrinsics.map(async (extrinsic) => {
-      const txs = await query.archive.contractTransactions({
+    extrinsics.map((extrinsic) =>
+      query.archive.contractTransactions({
         startBlock,
         endBlock,
         methodId: extrinsic.ID,
@@ -40,25 +40,8 @@ export default async function extrinsicsHandler(
           'input',
           'receiptStatus',
         ],
-      });
-      const _txs = await query.archive.contractTransactions({
-        startBlock,
-        endBlock,
-        methodId: extrinsic._ID,
-        properties: [
-          'hash',
-          'blockNumber',
-          'blockTimestamp',
-          'to',
-          'from',
-          'methodId',
-          'value',
-          'input',
-          'receiptStatus',
-        ],
-      });
-      return [...txs, ..._txs];
-    }),
+      }),
+    ),
   );
   // filter non-erc standard txs
   const uniqueContractAddresses = [...new Set(txs.flat().map((tx) => tx.to))];
@@ -74,9 +57,7 @@ export default async function extrinsicsHandler(
   await model.insertMany(
     ercTxs
       .map((tx) => {
-        const ex = extrinsics.find((ex) =>
-          [ex.ID, ex._ID].includes(tx.methodId),
-        )!;
+        const ex = extrinsics.find((ex) => ex.ID === tx.methodId)!;
         let decoded: DecodedExtrinsic;
 
         try {

--- a/packages/indexer-utils/src/types/contract.ts
+++ b/packages/indexer-utils/src/types/contract.ts
@@ -10,7 +10,6 @@ export enum ContractType {
 export type ContractSignatureItem = {
   SIGNATURE: string;
   ID: string;
-  _ID: string;
   PARAMS: string[];
   REQUIRED: boolean;
 };

--- a/packages/indexer-utils/src/utils/contract/contract-signatures.ts
+++ b/packages/indexer-utils/src/utils/contract/contract-signatures.ts
@@ -10,10 +10,6 @@ We return the ContractSignatures type and assign it to CONTRACT_SIGNATURES. Each
 2. The ID (first 8 characters of the hash, used to index transaction types in the archive)
 3. The params as an array (for decoding transaction input in indexers)
 4. Required, used along with the ID to identifying contract types in contract creation transactions
-
-The ugly uppercase is because these are constants. Apologies but it's important to keep that clear.
-
-ODD NOTE: some contracts prefix methods with an underscore, we use _ID to allow us to check that hash too
  */
 
 type SimpleContractSignatures = {
@@ -212,7 +208,6 @@ function createSignatureItem(
     REQUIRED: required,
     SIGNATURE: signature,
     ID: getMethodIdFromSignature(signature, events),
-    _ID: getMethodIdFromSignature(`_${signature}`, events),
     PARAMS: getParamsFromSignature(signature),
   };
 }

--- a/packages/indexer-utils/src/utils/contract/is-type.ts
+++ b/packages/indexer-utils/src/utils/contract/is-type.ts
@@ -3,20 +3,20 @@ import { ContractType } from '../../types/contract';
 
 export default function isType(type: ContractType, input: string) {
   const hasEvents = CONTRACT_SIGNATURES[type].EVENTS.every(
-    ({ ID, REQUIRED, _ID }) => {
+    ({ ID, REQUIRED }) => {
       if (!REQUIRED) return true;
 
-      return input.includes(ID) || input.includes(_ID);
+      return input.includes(ID);
     },
   );
 
   if (!hasEvents) return false;
 
   const hasExtrinsics = CONTRACT_SIGNATURES[type].EXTRINSICS.every(
-    ({ ID, REQUIRED, _ID }) => {
+    ({ ID, REQUIRED }) => {
       if (!REQUIRED) return true;
 
-      return input.includes(ID) || input.includes(_ID);
+      return input.includes(ID);
     },
   );
 

--- a/packages/indexer-utils/src/utils/contract/supports.ts
+++ b/packages/indexer-utils/src/utils/contract/supports.ts
@@ -39,7 +39,5 @@ export default {
 };
 
 function supports(interfaceSigs: ContractSignatureItem[], input: string) {
-  return interfaceSigs.every((sig) => {
-    return input.includes(sig.ID) || input.includes(sig._ID);
-  });
+  return interfaceSigs.every((sig) => input.includes(sig.ID));
 }


### PR DESCRIPTION
Detecting these was a mistake. I revisited the Rarible contract that led me to believe this was common, and it was the params not the method names that are underscored.

Closes #53 