### PR TITLE
Add basic metrics to contracts indexer

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,4 +26,4 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test
+        run: yarn test-ci

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "scripts": {
     "prepare": "husky install",
     "build": "yarn workspaces run build",
-    "test": "jest --silent",
+    "test": "jest",
+    "test-ci": "jest --silent",
     "coverage": "jest --silent --coverage"
   }
 }

--- a/packages/indexer-monitoring/src/monitoring.test.ts
+++ b/packages/indexer-monitoring/src/monitoring.test.ts
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks';
 import {
   Counter,
   Gauge,
@@ -9,20 +10,27 @@ import { Metric } from './metrics';
 import monitoring from './monitoring';
 
 jest.mock('prom-client');
+jest.mock('perf_hooks');
 
-const fakeMetric: Metric = {
+const firstFakeMetric: Metric = {
   functionName: 'fake_metric',
 };
 
-describe('AWS worker', () => {
+const secondFakeMetric: Metric = {
+  functionName: 'fake_metric2',
+};
+
+describe('Monitoring', () => {
   it('Returns the correct metric name with suffix', async () => {
-    expect(monitoring.getNameFromMetric(fakeMetric, 'test')).toStrictEqual(
+    expect(monitoring.getNameFromMetric(firstFakeMetric, 'test')).toStrictEqual(
       'test_indexer_fake_metric_test',
     );
   });
 
   it('Increments a counter by one', async () => {
-    monitoring.incCounter(1, fakeMetric);
+    const spy = jest.spyOn(Counter.prototype, 'inc');
+
+    monitoring.incCounter(1, firstFakeMetric);
 
     expect(Counter).toHaveBeenLastCalledWith({
       name: 'test_indexer_fake_metric_counter',
@@ -30,10 +38,17 @@ describe('AWS worker', () => {
       labelNames: ['chain', 'version'],
       registers: [globalRegistry],
     });
+
+    expect(spy).lastCalledWith(
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      1,
+    );
   });
 
   it('Sets a gauge by a specific value', async () => {
-    monitoring.gauge(1, fakeMetric);
+    const spy = jest.spyOn(Gauge.prototype, 'set');
+
+    monitoring.gauge(1, firstFakeMetric);
 
     expect(Gauge).toHaveBeenLastCalledWith({
       name: 'test_indexer_fake_metric_gauge',
@@ -41,10 +56,17 @@ describe('AWS worker', () => {
       labelNames: ['chain', 'version'],
       registers: [globalRegistry],
     });
+
+    expect(spy).lastCalledWith(
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      1,
+    );
   });
 
   it('Observes a value in a histogram', async () => {
-    monitoring.observe(1, fakeMetric);
+    const spy = jest.spyOn(Histogram.prototype, 'observe');
+
+    monitoring.observe(1, firstFakeMetric);
 
     expect(Histogram).toHaveBeenLastCalledWith({
       name: 'test_indexer_fake_metric_timer',
@@ -52,15 +74,86 @@ describe('AWS worker', () => {
       labelNames: ['chain', 'version'],
       registers: [globalRegistry],
     });
+
+    expect(spy).lastCalledWith(
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      1 / 1000,
+    );
   });
 
   it('Pushes metrics to the Pushgateway', async () => {
+    const spy = jest.spyOn(Pushgateway.prototype, 'pushAdd');
+
     monitoring.pushMetrics();
 
     expect(Pushgateway).toHaveBeenLastCalledWith(
       process.env.PUSHGATEWAY_URL!,
       {},
       globalRegistry,
+    );
+
+    expect(spy).lastCalledWith({
+      jobName: 'pushgateway',
+      groupings: {
+        chain: process.env.CHAIN!,
+        version: process.env.DEPLOY_VERSION!,
+      },
+    });
+  });
+
+  it('Observe a full flow of measurements', async () => {
+    const spy = jest.spyOn(Histogram.prototype, 'observe');
+
+    const performanceMock = performance.now as jest.Mock;
+    performanceMock.mockReturnValue(0);
+    monitoring.markStart(firstFakeMetric);
+    monitoring.markStart(secondFakeMetric);
+
+    performanceMock.mockReturnValue(1000);
+    monitoring.markEnd(firstFakeMetric);
+
+    performanceMock.mockReturnValue(2000);
+    monitoring.markEnd(secondFakeMetric);
+
+    monitoring.measure(firstFakeMetric);
+    monitoring.measure(secondFakeMetric);
+    monitoring.measure(secondFakeMetric, secondFakeMetric, firstFakeMetric);
+
+    expect(Histogram).toBeCalledTimes(3);
+    expect(Histogram).toHaveBeenNthCalledWith(1, {
+      name: 'test_indexer_fake_metric_timer',
+      help: `Elapsed time for the fake_metric function`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+    expect(Histogram).toHaveBeenNthCalledWith(2, {
+      name: 'test_indexer_fake_metric2_timer',
+      help: `Elapsed time for the fake_metric2 function`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+    expect(Histogram).toHaveBeenNthCalledWith(3, {
+      name: 'test_indexer_fake_metric2_timer',
+      help: `Elapsed time for the fake_metric2 function`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+
+    expect(spy).toBeCalledTimes(3);
+    expect(spy).toHaveBeenNthCalledWith(
+      1,
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      1,
+    );
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      2,
+    );
+    expect(spy).toHaveBeenNthCalledWith(
+      3,
+      { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
+      1,
     );
   });
 });

--- a/packages/indexer-monitoring/src/monitoring.test.ts
+++ b/packages/indexer-monitoring/src/monitoring.test.ts
@@ -1,4 +1,3 @@
-import { performance } from 'perf_hooks';
 import {
   Counter,
   Gauge,
@@ -10,7 +9,6 @@ import { Metric } from './metrics';
 import monitoring from './monitoring';
 
 jest.mock('prom-client');
-jest.mock('perf_hooks');
 
 const firstFakeMetric: Metric = {
   functionName: 'fake_metric',
@@ -104,15 +102,14 @@ describe('Monitoring', () => {
   it('Observe a full flow of measurements', async () => {
     const spy = jest.spyOn(Histogram.prototype, 'observe');
 
-    const performanceMock = performance.now as jest.Mock;
-    performanceMock.mockReturnValue(0);
+    global.Date.now = jest.fn(() => 0);
     monitoring.markStart(firstFakeMetric);
     monitoring.markStart(secondFakeMetric);
 
-    performanceMock.mockReturnValue(1000);
+    global.Date.now = jest.fn(() => 1000);
     monitoring.markEnd(firstFakeMetric);
 
-    performanceMock.mockReturnValue(2000);
+    global.Date.now = jest.fn(() => 2000);
     monitoring.markEnd(secondFakeMetric);
 
     monitoring.measure(firstFakeMetric);

--- a/packages/indexer-monitoring/src/monitoring.test.ts
+++ b/packages/indexer-monitoring/src/monitoring.test.ts
@@ -1,0 +1,66 @@
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Pushgateway,
+  register as globalRegistry,
+} from 'prom-client';
+import { Metric } from './metrics';
+import monitoring from './monitoring';
+
+jest.mock('prom-client');
+
+const fakeMetric: Metric = {
+  functionName: 'fake_metric',
+};
+
+describe('AWS worker', () => {
+  it('Returns the correct metric name with suffix', async () => {
+    expect(monitoring.getNameFromMetric(fakeMetric, 'test')).toStrictEqual(
+      'test_indexer_fake_metric_test',
+    );
+  });
+
+  it('Increments a counter by one', async () => {
+    monitoring.incCounter(1, fakeMetric);
+
+    expect(Counter).toHaveBeenLastCalledWith({
+      name: 'test_indexer_fake_metric_counter',
+      help: `Counter for the fake_metric function`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+  });
+
+  it('Sets a gauge by a specific value', async () => {
+    monitoring.gauge(1, fakeMetric);
+
+    expect(Gauge).toHaveBeenLastCalledWith({
+      name: 'test_indexer_fake_metric_gauge',
+      help: `Gauge for fake_metric`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+  });
+
+  it('Observes a value in a histogram', async () => {
+    monitoring.observe(1, fakeMetric);
+
+    expect(Histogram).toHaveBeenLastCalledWith({
+      name: 'test_indexer_fake_metric_timer',
+      help: `Elapsed time for the fake_metric function`,
+      labelNames: ['chain', 'version'],
+      registers: [globalRegistry],
+    });
+  });
+
+  it('Pushes metrics to the Pushgateway', async () => {
+    monitoring.pushMetrics();
+
+    expect(Pushgateway).toHaveBeenLastCalledWith(
+      process.env.PUSHGATEWAY_URL!,
+      {},
+      globalRegistry,
+    );
+  });
+});

--- a/packages/indexer-monitoring/src/monitoring.ts
+++ b/packages/indexer-monitoring/src/monitoring.ts
@@ -16,9 +16,10 @@ const monitoring = () => {
   let marks: MarkedTimestamp = {};
 
   const getNameFromMetric = (metric: Metric, suffix: string) => {
-    // return `${process.env.CHAIN}_${metric.serviceName}_${metric.functionName}_${metric.metricName}`.toLocaleLowerCase();
     return (
-      metric.functionName + (suffix ? '_' + suffix : '')
+      (process.env.SERVICE_NAME ? process.env.SERVICE_NAME + '_' : '') +
+      metric.functionName +
+      (suffix ? '_' + suffix : '')
     ).toLocaleLowerCase();
   };
 
@@ -113,6 +114,7 @@ const monitoring = () => {
     incCounter: (value: number, metric: Metric) => {
       const counter = getOrCreateCounter(metric);
 
+      console.log('do stuff');
       counter.inc(
         { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
         value,
@@ -130,10 +132,12 @@ const monitoring = () => {
         jobName: 'pushgateway',
         groupings: {
           chain: process.env.CHAIN!,
-          version: process.env.DEPLOY_VERSION!
-        }
+          version: process.env.DEPLOY_VERSION!,
+        },
       });
     },
+
+    getNameFromMetric,
   };
 };
 

--- a/packages/indexer-monitoring/src/monitoring.ts
+++ b/packages/indexer-monitoring/src/monitoring.ts
@@ -1,4 +1,3 @@
-import { performance } from 'perf_hooks';
 import {
   Counter,
   Gauge,
@@ -83,11 +82,11 @@ const monitoring = () => {
 
   return {
     markStart: (metric: Metric) => {
-      marks[`start-${metric.functionName}`] = performance.now();
+      marks[`start-${metric.functionName}`] = Date.now();
     },
 
     markEnd: (metric: Metric) => {
-      marks[`end-${metric.functionName}`] = performance.now();
+      marks[`end-${metric.functionName}`] = Date.now();
     },
 
     measure: (metric: Metric, startMetric?: Metric, endMetric?: Metric) => {

--- a/packages/indexer-monitoring/src/monitoring.ts
+++ b/packages/indexer-monitoring/src/monitoring.ts
@@ -25,6 +25,7 @@ const monitoring = () => {
 
   const getOrCreateHistogram = (metric: Metric): Histogram<string> => {
     const name = getNameFromMetric(metric, 'timer');
+    console.log(name);
 
     const promMetric = globalRegistry.getSingleMetric(name);
     if (promMetric) {
@@ -114,7 +115,6 @@ const monitoring = () => {
     incCounter: (value: number, metric: Metric) => {
       const counter = getOrCreateCounter(metric);
 
-      console.log('do stuff');
       counter.inc(
         { chain: process.env.CHAIN, version: process.env.DEPLOY_VERSION },
         value,

--- a/packages/indexer-serverless/src/functions/last-indexed-block/index.ts
+++ b/packages/indexer-serverless/src/functions/last-indexed-block/index.ts
@@ -20,6 +20,7 @@ export default function (config: Config, params: Params) {
       CHAIN: config.chain,
       DEPLOY_VERSION: config.version,
       PUSHGATEWAY_URL: stageConfig.getPushGatewayURL(),
+      SERVICE_NAME: config.serviceName,
     },
     timeout: 30,
   } as keyof AWS['functions'];

--- a/packages/indexer-serverless/src/functions/producer/index.ts
+++ b/packages/indexer-serverless/src/functions/producer/index.ts
@@ -30,7 +30,8 @@ export default function (config: Config, params: Params) {
       DEPLOY_VERSION: config.version,
       MAX_WORKERS: config.maxWorkers,
       TARGET_TOTAL_QUEUED_BLOCKS: config.targetTotalQueuedBlocks,
+      SERVICE_NAME: config.serviceName,
     },
-    timeout: 60
+    timeout: 60,
   } as keyof AWS['functions'];
 }

--- a/packages/indexer-serverless/src/functions/query/index.ts
+++ b/packages/indexer-serverless/src/functions/query/index.ts
@@ -1,6 +1,6 @@
-import { getContext } from '../../util/context';
 import stageConfigFactory from '../../config/stage-config';
 import { Config, Params } from '../../types';
+import { getContext } from '../../util/context';
 
 const context = getContext();
 
@@ -26,6 +26,7 @@ export default function (config: Config, params: Params) {
     ],
     environment: {
       MONGO_URI: stageConfig.getMongoURI(),
+      SERVICE_NAME: config.serviceName,
     },
   };
 }

--- a/packages/indexer-serverless/src/functions/worker/index.ts
+++ b/packages/indexer-serverless/src/functions/worker/index.ts
@@ -32,6 +32,7 @@ export default function (config: Config, params: Params) {
       PUSHGATEWAY_URL: stageConfig.getPushGatewayURL(),
       CHAIN: config.chain,
       DEPLOY_VERSION: config.version,
+      SERVICE_NAME: config.serviceName,
     },
     timeout: 60,
     memorySize: 2048,

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -28,6 +28,7 @@ beforeAll(async () => {
   process.env.END_BLOCK = 'undefined';
   process.env.LATEST_BLOCK_DEPENDENCY = 'archive-node';
   process.env.PUSHGATEWAY_URL = 'test';
+  process.env.SERVICE_NAME = 'test_indexer';
 
   mongoServer = await MongoMemoryServer.create();
   process.env.MONGO_URI = mongoServer.getUri();


### PR DESCRIPTION
Closes #81 

Most of the indexers follow extract->transform->load quite clearly, but this this one merges transform & load.

Also, perhaps we should change the metric names from `extractBlock` to `extract` as it's often more than a block being handled.