### PR TITLE
Ops chores

### DIFF
--- a/indexers/archive/src/schema/log.ts
+++ b/indexers/archive/src/schema/log.ts
@@ -5,7 +5,7 @@ import getEnvVar from 'indexer-serverless/lib/util/get-env-var';
 
 const schemaOptions: mongoose.SchemaOptions = {};
 if (getEnvVar('SHARDING_ENABLED', false)) {
-  schemaOptions.shardKey = { hash: 'hashed' };
+  schemaOptions.shardKey = { _id: 'hashed' };
 }
 
 // @ts-ignore

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.17.21",
     "mongoose": "^6.2.11",
     "prom-client": "^14.0.1",
+    "serverless-domain-manager": "^6.0.3",
     "web3": "^v3.0.0-rc.5"
   },
   "devDependencies": {

--- a/packages/indexer-serverless/src/serverless.ts
+++ b/packages/indexer-serverless/src/serverless.ts
@@ -69,7 +69,11 @@ const getConfig = async (config: Config) => {
   const serverlessConfiguration: AWS = {
     service: `${config.chain}-${config.serviceName}-${config.version}`,
     frameworkVersion: '3',
-    plugins: ['serverless-esbuild', 'serverless-localstack'],
+    plugins: [
+      'serverless-esbuild',
+      'serverless-localstack',
+      'serverless-domain-manager',
+    ],
     provider: {
       name: 'aws',
       runtime: 'nodejs14.x',
@@ -165,6 +169,14 @@ const getConfig = async (config: Config) => {
         define: { 'require.resolve': undefined },
         platform: 'node',
         concurrency: 10,
+      },
+      customDomain: {
+        domainName: `${params.chain}-${params.indexer}-${params.version}.graph.eng.litentry.io`,
+        createRoute53Record: true,
+        endpointType: 'regional',
+        securityPolicy: 'tls_1_2',
+        apiType: 'rest',
+        autoDomain: true,
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,6 +1797,21 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+aws-sdk@^2.1113.0:
+  version "2.1166.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1166.0.tgz#9bc5ceb3690d2747b941a2e2b8ebacfffb412f41"
+  integrity sha512-9CJQpMtIv2sxvwYTcMCfuCGU8t5qEppnvmo0uFFOm+1Q1uEv5sPg95wQH3Gfj4Mmv4FKWFofgTLksn0u2pDxsw==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "8.0.0"
+    xml2js "0.4.19"
+
 aws-sdk@^2.1119.0, aws-sdk@^2.402.0:
   version "2.1124.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1124.0.tgz#350550b973f210b092a45184036659251d7cbd1e"
@@ -6905,6 +6920,13 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
+serverless-domain-manager@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/serverless-domain-manager/-/serverless-domain-manager-6.0.3.tgz#1a19fb2b9ff7d8542c0c891bf4d57e8f4b1f70d6"
+  integrity sha512-vwIhxaUpAf32I3fxuY0gHoZKHlPmWXZQZPfbN3kRz7UIo6j7Zf+FlL4dUm5JYWz7B2gPEz1ZPW9mBtPeAVbEAg==
+  dependencies:
+    aws-sdk "^2.1113.0"
+
 serverless-esbuild@^1.23.3:
   version "1.26.2"
   resolved "https://registry.yarnpkg.com/serverless-esbuild/-/serverless-esbuild-1.26.2.tgz#751fee753e3bcefa75d3610f18fdc257197ab89a"
@@ -7691,9 +7713,9 @@ undefsafe@^2.0.5:
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 underscore@1.12.1, underscore@1.9.1, underscore@^1.12.1:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
-  integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.4.tgz#7886b46bbdf07f768e0052f1828e1dcab40c0dee"
+  integrity sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==
 
 uni-global@^1.0.0:
   version "1.0.0"
@@ -7809,6 +7831,11 @@ uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^8.3.1, uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Two things:

- Custom APIGW domain support for GraphQL endpoint
- In a sharded Mongo cluster, split routers into primary and secondaries. 
  - Shards should now coordinate with each other using the primary router only - previously they could communicate with each other via ANY router, which means they could not always find each other when the router instance count was >1, as each shard could connect to a different router instance. This stopped cluster startup from succeeding.
  - However this means at least two routers are required, as with ECS you can't additionally bind the primary router to the pool of secondaries, which the indexer expects to connect to. 