### PR TITLE
Erc20 schema fixes

### DIFF
--- a/indexers/erc20-tokens/src/indexer/transform.ts
+++ b/indexers/erc20-tokens/src/indexer/transform.ts
@@ -6,37 +6,47 @@ export default function transform({
   transferLogs,
   erc20Contracts,
 }: ExtractedData): ERC20Transfer[] {
-  const transfers = transferLogs.map((log) => {
-    const { to, from, amount } = decodeTransfer(log.data, [
-      log.topic0,
-      log.topic1!,
-      log.topic2!,
-    ]);
+  const transfers = transferLogs.reduce((prev, log) => {
+    try {
+      const { to, from, amount } = decodeTransfer(log.data, [
+        log.topic0,
+        log.topic1!,
+        log.topic2!,
+      ]);
 
-    const contract = erc20Contracts.find(
-      (contract) => contract._id === log.address,
-    )!;
+      const contract = erc20Contracts.find(
+        (contract) => contract._id === log.address,
+      )!;
 
-    const transfer: ERC20Transfer = {
-      _id: log._id,
-      contract: log.address,
-      from,
-      to,
-      amount,
-      amountFormatted: contract.decimals
-        ? new BN(amount).shiftedBy(-contract.decimals).toString()
-        : undefined,
-      decimals: contract.decimals,
-      name: contract.name,
-      symbol: contract.symbol,
-      blockNumber: log.blockNumber,
-      blockTimestamp: log.blockTimestamp,
-      transactionHash: log.transactionHash,
-      transactionId: log.transactionId,
-    };
+      const transfer: ERC20Transfer = {
+        _id: log._id,
+        contract: log.address,
+        from,
+        to,
+        amount,
+        amountFormatted: contract.decimals
+          ? new BN(amount).shiftedBy(-contract.decimals).toString()
+          : undefined,
+        decimals: contract.decimals,
+        name: contract.name,
+        symbol: contract.symbol,
+        blockNumber: log.blockNumber,
+        blockTimestamp: log.blockTimestamp,
+        transactionHash: log.transactionHash,
+        transactionId: log.transactionId,
+      };
 
-    return transfer;
-  });
+      return [...prev, transfer];
+    } catch (e) {
+      console.error(
+        `Non compliant log on tx: ${log.transactionHash} at index ${log.logIndex}`,
+      );
+      /*
+      Some transactions emit dodgy logs e.g. https://etherscan.io/tx/0x67b36471c1795588ac7174a73d22f32e6e1956a30dd26d2e8b5c0f9e72b8141b
+      */
+      return prev;
+    }
+  }, [] as ERC20Transfer[]);
 
   return transfers;
 }

--- a/indexers/erc20-tokens/src/schema.ts
+++ b/indexers/erc20-tokens/src/schema.ts
@@ -14,6 +14,11 @@ export const ERC20TransferSchema = new mongoose.Schema<ERC20TransferDocument>({
   contract: { type: String, required: true },
   from: { type: String, required: true },
   to: { type: String, required: true },
+  amount: { type: String, required: true },
+  amountFormatted: String,
+  name: String,
+  symbol: String,
+  decimals: Number,
   blockNumber: { type: Number, required: true },
   blockTimestamp: { type: Number, required: true },
   transactionHash: { type: String, required: true },
@@ -44,9 +49,9 @@ schemaComposer.Query.addFields({
     }`,
     args: {
       contract: 'String!',
-      account: 'String!',
+      address: 'String!',
     },
-    resolve: async ({ args }): Promise<ERC20Balance> => {
+    resolve: async (_, args): Promise<ERC20Balance> => {
       const contract = new (web3() as Web3).eth.Contract(
         [
           {
@@ -82,7 +87,7 @@ schemaComposer.Query.addFields({
       const { decimals, symbol, name } = contractData[0] || {};
 
       let amountFormatted;
-      if (decimals) {
+      if (typeof decimals === 'number') {
         amountFormatted = new BN(amount).shiftedBy(-decimals).toString();
       }
 


### PR DESCRIPTION
- Closes #110 where the custom query args were in the wrong place - context should have been the first arg
- Closes #111 where some properties were missing from the mongoose schema for token transfers
- Closes #112 this was initially a result of bad config (batches too big to process), however non compliant token transfers also needed to be handled (see https://etherscan.io/tx/0x67b36471c1795588ac7174a73d22f32e6e1956a30dd26d2e8b5c0f9e72b8141b and https://info.etherscan.com/what-happens-when-erc-20-token-transfer-might-have-failed/) 