### PR TITLE
Fix amountFormatted & reduce queried data

### DIFF
--- a/indexers/erc20-tokens/src/indexer/extract.ts
+++ b/indexers/erc20-tokens/src/indexer/extract.ts
@@ -1,9 +1,6 @@
-import { query, utils } from 'indexer-utils';
+import { query } from 'indexer-utils';
 import { ExtractedData } from './types';
-
-const signature = utils.contract.CONTRACT_SIGNATURES.ERC20.EVENTS.find(
-  (item) => item.SIGNATURE === 'Transfer(address,address,uint256)',
-)!;
+import { TRANSFER_EVENT_SIGNATURE } from './utils';
 
 export default async function extract(
   startBlock: number,
@@ -13,7 +10,19 @@ export default async function extract(
   const logs = await query.archive.logs({
     startBlock,
     endBlock,
-    eventId: `0x${signature.ID}`,
+    eventId: TRANSFER_EVENT_SIGNATURE,
+    properties: [
+      '_id',
+      'address',
+      'topic1',
+      'topic2',
+      'topic3',
+      'data',
+      'blockNumber',
+      'blockTimestamp',
+      'transactionHash',
+      'transactionId',
+    ],
   });
   const filteredLogs = logs.filter((log) => {
     /*

--- a/indexers/erc20-tokens/src/indexer/transform.ts
+++ b/indexers/erc20-tokens/src/indexer/transform.ts
@@ -1,6 +1,6 @@
 import BN from 'bignumber.js';
 import { ERC20Transfer, ExtractedData } from './types';
-import { decodeTransfer } from './utils';
+import { decodeTransfer, TRANSFER_EVENT_SIGNATURE } from './utils';
 
 export default function transform({
   transferLogs,
@@ -9,7 +9,7 @@ export default function transform({
   const transfers = transferLogs.reduce((prev, log) => {
     try {
       const { to, from, amount } = decodeTransfer(log.data, [
-        log.topic0,
+        TRANSFER_EVENT_SIGNATURE,
         log.topic1!,
         log.topic2!,
       ]);
@@ -23,9 +23,9 @@ export default function transform({
         contract: log.address,
         from,
         to,
-        amount,
+        amount: amount.toString(),
         amountFormatted: contract.decimals
-          ? new BN(amount).shiftedBy(-contract.decimals).toString()
+          ? new BN(amount.toString()).shiftedBy(-contract.decimals).toString()
           : undefined,
         decimals: contract.decimals,
         name: contract.name,

--- a/indexers/erc20-tokens/src/indexer/transform.ts
+++ b/indexers/erc20-tokens/src/indexer/transform.ts
@@ -1,4 +1,3 @@
-import BN from 'bignumber.js';
 import { ERC20Transfer, ExtractedData } from './types';
 import { decodeTransfer, TRANSFER_EVENT_SIGNATURE } from './utils';
 
@@ -24,9 +23,6 @@ export default function transform({
         from,
         to,
         amount: amount.toString(),
-        amountFormatted: contract.decimals
-          ? new BN(amount.toString()).shiftedBy(-contract.decimals).toString()
-          : undefined,
         decimals: contract.decimals,
         name: contract.name,
         symbol: contract.symbol,

--- a/indexers/erc20-tokens/src/indexer/types.ts
+++ b/indexers/erc20-tokens/src/indexer/types.ts
@@ -1,6 +1,6 @@
 import { Types } from 'indexer-utils';
 
-export interface ERC20Transfer extends ERC20Balance {
+export type ERC20Transfer = {
   _id: string;
   contract: string;
   from: string;
@@ -9,7 +9,11 @@ export interface ERC20Transfer extends ERC20Balance {
   blockTimestamp: number;
   transactionHash: string;
   transactionId: string;
-}
+  amount: string;
+  name?: string;
+  symbol?: string;
+  decimals?: number;
+};
 
 export type ERC20Balance = {
   amount: string;

--- a/indexers/erc20-tokens/src/indexer/utils.ts
+++ b/indexers/erc20-tokens/src/indexer/utils.ts
@@ -1,5 +1,8 @@
-import { ethers } from 'ethers';
 import ERC20 from '@openzeppelin/contracts/build/contracts/ERC20.json';
+import { ethers } from 'ethers';
+
+export const TRANSFER_EVENT_SIGNATURE =
+  '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 
 export function decodeTransfer(data: string, topics: string[]) {
   const decoded = new ethers.utils.Interface(ERC20.abi).decodeEventLog(

--- a/indexers/erc20-tokens/src/schema.ts
+++ b/indexers/erc20-tokens/src/schema.ts
@@ -1,10 +1,10 @@
-import Web3 from 'web3';
 import BN from 'bignumber.js';
 import { schemaComposer } from 'graphql-compose';
 import { composeMongoose } from 'graphql-compose-mongoose';
+import { filter, query, repository, web3 } from 'indexer-utils';
 import mongoose from 'mongoose';
-import { filter, repository, web3, query } from 'indexer-utils';
-import { ERC20Transfer, ERC20Balance } from './indexer/types';
+import Web3 from 'web3';
+import { ERC20Balance, ERC20Transfer } from './indexer/types';
 
 // @ts-ignore
 interface ERC20TransferDocument extends ERC20Transfer, mongoose.Document {}
@@ -15,7 +15,6 @@ export const ERC20TransferSchema = new mongoose.Schema<ERC20TransferDocument>({
   from: { type: String, required: true },
   to: { type: String, required: true },
   amount: { type: String, required: true },
-  amountFormatted: String,
   name: String,
   symbol: String,
   decimals: Number,


### PR DESCRIPTION
`amount` was an ethers js type of BigNumber so passing it into a `bignumber.js` type of BigNumber causes NaN. Amount was unaffected as mongo must have been calling the `toString()` method under the hood and saving it as the intended type.