### PR TITLE
Fix NFT decoding issues

### DIFF
--- a/indexers/nft/src/indexer/transform/decode-erc1155-batch-token-transfers.ts
+++ b/indexers/nft/src/indexer/transform/decode-erc1155-batch-token-transfers.ts
@@ -3,40 +3,53 @@ import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
 import { Types } from 'indexer-utils';
 
+type Decoded = [string, string, string, BigNumber[], BigNumber[]];
+
 export default function decodeErc1155BatchTokenTransfers(
   logs: Types.Archive.Log[],
   contracts: Types.Contract.ERC1155Contract[],
 ): Types.Nft.ERC1155TokenTransfer[] {
-  return logs
-    .map((log) => {
-      const decoded = new ethers.utils.Interface(ERC1155.abi).decodeEventLog(
+  return logs.reduce((prev, log) => {
+    let decoded: Decoded;
+
+    try {
+      decoded = new ethers.utils.Interface(ERC1155.abi).decodeEventLog(
         'TransferBatch(address,address,address,uint256[],uint256[])',
         log.data,
         [log.topic0, log.topic1!, log.topic2!, log.topic3!],
+      ) as Decoded;
+    } catch (e) {
+      console.error(
+        `Non compliant log on tx: ${log.transactionHash} at index ${log.logIndex}`,
       );
+      /*
+      Some transactions emit dodgy logs e.g. https://etherscan.io/tx/0x043f5291b40c6b8c47f6e5578942ac60bed0284b10de7baf9394317b0b70ec1f
+      */
+      return prev;
+    }
 
-      const shared = {
-        _id: log._id,
-        contract: log.address,
-        from: (decoded[1] as string).toLowerCase(),
-        to: (decoded[2] as string).toLowerCase(),
-        transactionHash: log.transactionHash,
-        transactionId: log.transactionId,
-        blockNumber: log.blockNumber,
-        blockTimestamp: log.blockTimestamp,
-        collectionName: contracts.find(
-          (contract) => contract._id === log.address,
-        )?.name,
+    const shared = {
+      _id: log._id,
+      contract: log.address,
+      from: (decoded[1] as string).toLowerCase(),
+      to: (decoded[2] as string).toLowerCase(),
+      transactionHash: log.transactionHash,
+      transactionId: log.transactionId,
+      blockNumber: log.blockNumber,
+      blockTimestamp: log.blockTimestamp,
+      collectionName: contracts.find((contract) => contract._id === log.address)
+        ?.name,
+    };
+
+    const transfers = (decoded[3] as BigNumber[]).map((tokenId, i) => {
+      const transfer: Types.Nft.ERC1155TokenTransfer = {
+        tokenId: tokenId.toString(),
+        quantity: (decoded[4][i] as BigNumber).toNumber(),
+        ...shared,
       };
+      return transfer;
+    });
 
-      return (decoded[3] as BigNumber[]).map((tokenId, i) => {
-        const transfer: Types.Nft.ERC1155TokenTransfer = {
-          tokenId: tokenId.toString(),
-          quantity: (decoded[4][i] as BigNumber).toNumber(),
-          ...shared,
-        };
-        return transfer;
-      });
-    })
-    .flat();
+    return [...prev, ...transfers];
+  }, [] as Types.Nft.ERC1155TokenTransfer[]);
 }

--- a/indexers/nft/src/indexer/transform/decode-erc1155-batch-token-transfers.ts
+++ b/indexers/nft/src/indexer/transform/decode-erc1155-batch-token-transfers.ts
@@ -1,6 +1,6 @@
+import ERC1155 from '@openzeppelin/contracts/build/contracts/ERC1155.json';
 import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
-import ERC1155 from '@openzeppelin/contracts/build/contracts/ERC1155.json';
 import { Types } from 'indexer-utils';
 
 export default function decodeErc1155BatchTokenTransfers(
@@ -12,7 +12,7 @@ export default function decodeErc1155BatchTokenTransfers(
       const decoded = new ethers.utils.Interface(ERC1155.abi).decodeEventLog(
         'TransferBatch(address,address,address,uint256[],uint256[])',
         log.data,
-        [log.topic0, log.topic1!, log.topic2!, log.topic3!, log.topic4!],
+        [log.topic0, log.topic1!, log.topic2!, log.topic3!],
       );
 
       const shared = {

--- a/indexers/nft/src/indexer/transform/decode-erc1155-single-token-transfers.ts
+++ b/indexers/nft/src/indexer/transform/decode-erc1155-single-token-transfers.ts
@@ -3,16 +3,28 @@ import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
 import { Types } from 'indexer-utils';
 
+type Decoded = [string, string, string, BigNumber, BigNumber];
+
 export default function decodeErc1155SingleTokenTransfers(
   logs: Types.Archive.Log[],
   contracts: Types.Contract.ERC1155Contract[],
 ): Types.Nft.ERC1155TokenTransfer[] {
-  return logs.map((log) => {
-    const decoded = new ethers.utils.Interface(ERC1155.abi).decodeEventLog(
-      'TransferSingle(address,address,address,uint256,uint256)',
-      log.data,
-      [log.topic0, log.topic1!, log.topic2!, log.topic3!],
-    );
+  return logs.reduce((prev, log) => {
+    let decoded: Decoded;
+
+    try {
+      decoded = new ethers.utils.Interface(ERC1155.abi).decodeEventLog(
+        'TransferSingle(address,address,address,uint256,uint256)',
+        log.data,
+        [log.topic0, log.topic1!, log.topic2!, log.topic3!],
+      ) as Decoded;
+    } catch (e) {
+      console.error(
+        `Non compliant log on tx: ${log.transactionHash} at index ${log.logIndex}`,
+      );
+      return prev;
+    }
+
     const transfer: Types.Nft.ERC1155TokenTransfer = {
       _id: log._id,
       contract: log.address,
@@ -27,6 +39,6 @@ export default function decodeErc1155SingleTokenTransfers(
       collectionName: contracts.find((contract) => contract._id === log.address)
         ?.name,
     };
-    return transfer;
-  });
+    return [...prev, transfer];
+  }, [] as Types.Nft.ERC1155TokenTransfer[]);
 }

--- a/indexers/nft/src/indexer/transform/decode-erc721-token-transfers.ts
+++ b/indexers/nft/src/indexer/transform/decode-erc721-token-transfers.ts
@@ -1,17 +1,29 @@
-import { ethers, BigNumber } from 'ethers';
 import ERC721 from '@openzeppelin/contracts/build/contracts/ERC721.json';
+import { BigNumber, ethers } from 'ethers';
 import { Types } from 'indexer-utils';
+
+type Decoded = [string, string, BigNumber];
 
 export default function decodeErc721TokenTransfers(
   logs: Types.Archive.Log[],
   contracts: Types.Contract.ERC721Contract[],
 ): Types.Nft.ERC721TokenTransfer[] {
-  return logs.map((log) => {
-    const decoded = new ethers.utils.Interface(ERC721.abi).decodeEventLog(
-      'Transfer(address,address,uint256)',
-      log.data,
-      [log.topic0, log.topic1!, log.topic2!, log.topic3!],
-    );
+  return logs.reduce((prev, log) => {
+    let decoded: Decoded;
+
+    try {
+      decoded = new ethers.utils.Interface(ERC721.abi).decodeEventLog(
+        'Transfer(address,address,uint256)',
+        log.data,
+        [log.topic0, log.topic1!, log.topic2!, log.topic3!],
+      ) as Decoded;
+    } catch (e) {
+      console.error(
+        `Non compliant log on tx: ${log.transactionHash} at index ${log.logIndex}`,
+      );
+      return prev;
+    }
+
     const transfer: Types.Nft.ERC721TokenTransfer = {
       _id: log._id,
       contract: log.address,
@@ -25,6 +37,6 @@ export default function decodeErc721TokenTransfers(
       collectionName: contracts.find((contract) => contract._id === log.address)
         ?.name,
     };
-    return transfer;
-  });
+    return [...prev, transfer];
+  }, [] as Types.Nft.ERC721TokenTransfer[]);
 }


### PR DESCRIPTION
1155 TransferBatch had the same issue with the token IDs as TransferSingle (should be in the data not topics), and they all had to handle errors from non compliant logs, this was also an issue on ERC20 event decoding