### PR TITLE
Fix last indexed block + add tests

### DIFF
--- a/packages/indexer-utils/src/repository/indexed-block-range.test.ts
+++ b/packages/indexer-utils/src/repository/indexed-block-range.test.ts
@@ -1,0 +1,71 @@
+import * as repository from './indexed-block-range';
+
+beforeEach(async () => {
+  await repository.save(0, 1);
+  await repository.save(2, 3);
+  await repository.save(4, 5);
+});
+
+afterEach(async () => {
+  await repository.Model.deleteMany();
+});
+
+describe('Indexed block range repository', () => {
+  it('Should get block ranges', async () => {
+    const data = await repository.get(1);
+    expect(data).toHaveLength(1);
+    expect(data[0].startBlock).toStrictEqual(0);
+    expect(data[0].endBlock).toStrictEqual(1);
+  });
+
+  it('Should get block ranges using a limit', async () => {
+    const fetch0 = await repository.get(0);
+    expect(fetch0).toHaveLength(3);
+    expect(fetch0[0].startBlock).toStrictEqual(0);
+    expect(fetch0[0].endBlock).toStrictEqual(1);
+    expect(fetch0[1].startBlock).toStrictEqual(2);
+    expect(fetch0[1].endBlock).toStrictEqual(3);
+    expect(fetch0[2].startBlock).toStrictEqual(4);
+    expect(fetch0[2].endBlock).toStrictEqual(5);
+
+    const fetch1 = await repository.get(1);
+    expect(fetch1).toHaveLength(1);
+    expect(fetch1[0].startBlock).toStrictEqual(0);
+    expect(fetch1[0].endBlock).toStrictEqual(1);
+
+    const fetch3 = await repository.get(3);
+    expect(fetch3).toHaveLength(3);
+    expect(fetch3[0].startBlock).toStrictEqual(0);
+    expect(fetch3[0].endBlock).toStrictEqual(1);
+    expect(fetch3[1].startBlock).toStrictEqual(2);
+    expect(fetch3[1].endBlock).toStrictEqual(3);
+    expect(fetch3[2].startBlock).toStrictEqual(4);
+    expect(fetch3[2].endBlock).toStrictEqual(5);
+
+    const fetch500 = await repository.get(500);
+    expect(fetch500).toHaveLength(3);
+    expect(fetch500[0].startBlock).toStrictEqual(0);
+    expect(fetch500[0].endBlock).toStrictEqual(1);
+    expect(fetch500[1].startBlock).toStrictEqual(2);
+    expect(fetch500[1].endBlock).toStrictEqual(3);
+    expect(fetch500[2].startBlock).toStrictEqual(4);
+    expect(fetch500[2].endBlock).toStrictEqual(5);
+  });
+
+  it('Should remove block ranges', async () => {
+    const data = await repository.get(0);
+    expect(data).toHaveLength(3);
+
+    await repository.remove(data);
+
+    expect(await repository.get(0)).toHaveLength(0);
+  });
+
+  it('Should save block ranges', async () => {
+    await repository.save(100, 200);
+    const data = await repository.get(0);
+    expect(data).toHaveLength(4);
+    expect(data[3].startBlock).toStrictEqual(100);
+    expect(data[3].endBlock).toStrictEqual(200);
+  });
+});

--- a/packages/indexer-utils/src/repository/indexed-block-range.ts
+++ b/packages/indexer-utils/src/repository/indexed-block-range.ts
@@ -18,10 +18,12 @@ export const Model = mongoose.model(
 export const save = (startBlock: number, endBlock: number) =>
   Model.create({ startBlock, endBlock });
 
-export const get = (): Promise<IndexedBlockRangeDocument[]> =>
-  Model.find({}).sort('startBlock').exec();
+export const get = (limit: number): Promise<IndexedBlockRangeDocument[]> =>
+  Model.find({}).sort('startBlock').limit(limit).exec();
 
 export const remove = (indexedBlockRanges: IndexedBlockRangeDocument[]) =>
-  Promise.all(
-    indexedBlockRanges.map((indexedBlockRange) => indexedBlockRange.delete()),
-  );
+  Model.deleteMany({
+    _id: {
+      $in: indexedBlockRanges.map((indexedBlockRange) => indexedBlockRange._id),
+    },
+  });

--- a/packages/indexer-utils/src/repository/last-indexed-block.test.ts
+++ b/packages/indexer-utils/src/repository/last-indexed-block.test.ts
@@ -1,0 +1,35 @@
+import * as indexedBlockRangeRepository from './indexed-block-range';
+import * as repository from './last-indexed-block';
+
+beforeEach(async () => {
+  await repository.save(10);
+});
+
+afterEach(async () => {
+  await repository.Model.deleteMany();
+});
+
+describe('Indexed block range repository', () => {
+  it('Should get last indexed block', async () => {
+    expect(await repository.get()).toStrictEqual(10);
+  });
+
+  it('Should save last indexed block', async () => {
+    expect(await repository.get()).toStrictEqual(10);
+
+    await repository.save(20);
+
+    expect(await repository.get()).toStrictEqual(20);
+  });
+
+  it('Should calculate lastIndexedBlock through ranges and update', async () => {
+    indexedBlockRangeRepository.save(11, 20);
+    indexedBlockRangeRepository.save(21, 30);
+    indexedBlockRangeRepository.save(41, 50);
+    indexedBlockRangeRepository.save(100, 20300);
+
+    await repository.calculateAndUpdate();
+
+    expect(await repository.get()).toStrictEqual(30);
+  });
+});

--- a/packages/indexer-utils/src/repository/last-indexed-block.test.ts
+++ b/packages/indexer-utils/src/repository/last-indexed-block.test.ts
@@ -32,4 +32,23 @@ describe('Indexed block range repository', () => {
 
     expect(await repository.get()).toStrictEqual(30);
   });
+
+  it('Should calculate lastIndexedBlock through ranges and update using limit', async () => {
+    indexedBlockRangeRepository.save(11, 20);
+    indexedBlockRangeRepository.save(21, 30);
+    indexedBlockRangeRepository.save(41, 50);
+    indexedBlockRangeRepository.save(100, 20300);
+
+    await repository.calculateAndUpdate(1);
+
+    expect(await repository.get()).toStrictEqual(20);
+
+    await repository.calculateAndUpdate(1);
+
+    expect(await repository.get()).toStrictEqual(30);
+
+    await repository.calculateAndUpdate(1);
+
+    expect(await repository.get()).toStrictEqual(30);
+  });
 });

--- a/packages/indexer-utils/src/repository/last-indexed-block.ts
+++ b/packages/indexer-utils/src/repository/last-indexed-block.ts
@@ -35,10 +35,14 @@ export const save = async (lastIndexedBlock: number): Promise<void> => {
   await currentValue.updateOne({ lastIndexedBlock });
 };
 
-export const calculateAndUpdate = async (): Promise<number> => {
+export const calculateAndUpdate = async (
+  maxNumberOfPendingRanges?: number,
+): Promise<number> => {
   let lastIndexedBlock = await get();
   const processedIndexedBlockRanges: IndexedBlockRangeDocument[] = [];
-  const pendingIndexedBlockRanges = await getIndexedBlockRanges(500);
+  const pendingIndexedBlockRanges = await getIndexedBlockRanges(
+    maxNumberOfPendingRanges || 500,
+  );
 
   pendingIndexedBlockRanges.forEach((pendingIndexedBlockRange) => {
     if ((lastIndexedBlock || 0) + 1 < pendingIndexedBlockRange.startBlock) {


### PR DESCRIPTION
In this PR we've:
- Remove noisy logs
- Remove redundant monitoring tracking
- Add limit to the pending ranges and default it to 500 in the lambda execution
- Add tests to both repos (lastIndexedBlock and indexedBlockRange)